### PR TITLE
Change Postgis dependency

### DIFF
--- a/geo_query.gemspec
+++ b/geo_query.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
 
   s.add_dependency "rails", "~> 4.2"
-  s.add_dependency 'activerecord-postgis-adapter', '3.1.0'
+  s.add_dependency 'activerecord-postgis-adapter', '~> 3.1'
 
   s.add_development_dependency "pg"
   s.add_development_dependency 'rspec-rails'


### PR DESCRIPTION
Allow Postgis to be compatible with minor updates.
Current version is 3.1.3, this allows that gem to be compatible
